### PR TITLE
Remove "Backend" from string

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
 		<service
 			android:name=".BackendService"
-			android:label="OpenWlanMap Backend"
+			android:label="OpenWlanMap"
 			android:permission="android.permission.ACCESS_COARSE_LOCATION">
 			<intent-filter>
 				<action android:name="org.microg.nlp.LOCATION_BACKEND" />


### PR DESCRIPTION
Avoid needless repetition: This is displayed in a menu where it already says in the title bar that backends are configured.